### PR TITLE
Add Streamlit UI with PDF export

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,3 +437,12 @@ Both evaluation systems complement each other and provide comprehensive coverage
 
 ### Local deployment
 
+To try the assistant with a simple web interface, run the Streamlit app:
+
+```bash
+streamlit run streamlit_app.py
+```
+
+Enter a question, wait for the research to complete, and then download the
+generated report as a PDF.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ dependencies = [
     "rich>=13.0.0",
     "singlestoredb>=0.1.0",
     "langsmith>=0.3.37",
+    "streamlit>=1.46.0",
+    "fpdf>=1.7.2",
 ]
 
 [project.optional-dependencies]

--- a/src/open_deep_research/__init__.py
+++ b/src/open_deep_research/__init__.py
@@ -1,3 +1,4 @@
 """Planning, research, and report generation."""
 
-__version__ = "0.0.15"
+__version__ = "0.0.16"
+

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,47 @@
+import asyncio
+import uuid
+import streamlit as st
+from fpdf import FPDF
+
+from open_deep_research.graph import run_graph
+
+
+def generate_report(topic: str) -> str:
+    """Run the graph workflow and return the final report."""
+    config = {"thread_id": str(uuid.uuid4())}
+    state = asyncio.run(run_graph(topic, config))
+    return state.get("final_report", "")
+
+
+def report_to_pdf(report: str) -> bytes:
+    """Convert a markdown report string to a PDF and return the bytes."""
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_auto_page_break(auto=True, margin=15)
+    pdf.set_font("Arial", size=12)
+    for line in report.splitlines():
+        pdf.multi_cell(0, 10, line)
+    return pdf.output(dest="S").encode("latin-1")
+
+
+st.title("Open Deep Research")
+
+question = st.text_input("Enter your research question")
+
+if st.button("Run Research"):
+    if not question:
+        st.warning("Please enter a question to research.")
+    else:
+        with st.spinner("Generating report..."):
+            report = generate_report(question)
+        st.session_state["report"] = report
+        st.markdown(report)
+
+if "report" in st.session_state:
+    pdf_bytes = report_to_pdf(st.session_state["report"])
+    st.download_button(
+        label="Download PDF",
+        data=pdf_bytes,
+        file_name="report.pdf",
+        mime="application/pdf",
+    )


### PR DESCRIPTION
## Summary
- add a simple Streamlit app for running the graph workflow and exporting the report to PDF
- include Streamlit and FPDF dependencies
- bump package version
- document how to launch the UI in README

## Testing
- `python -m pytest -q` *(fails: LangSmithConnectionError due to blocked network)*

------
https://chatgpt.com/codex/tasks/task_e_68718920bf28832e8d01dd992e39f375